### PR TITLE
Fix: Murmur theme not highlighting the search item in picker.

### DIFF
--- a/murmur.toml
+++ b/murmur.toml
@@ -98,7 +98,7 @@
 "ui.text.focus" = { fg = "color4", modifiers = ["bold"] }
 "ui.text.inactive" = { fg = "color8" }
 "ui.text.info" = { fg = "color6" }
-"ui.highlight" = { fg = "color3" }
+"ui.highlight" = { bg = "color0", fg = "color6", modifiers = ["bold"] }
 
 "ui.cursor.primary" = { fg = "background", bg = "foreground" }
 "ui.cursor.select" = { fg = "color0", bg = "color6" }


### PR DESCRIPTION
#3 

After this change I am able to see the match line highlighted in the modal.